### PR TITLE
Add route messages

### DIFF
--- a/marti_common_msgs/CMakeLists.txt
+++ b/marti_common_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_message_files(FILES
   Int32Stamped.msg
   Int64Stamped.msg
   Int8Stamped.msg
+  KeyValue.msg
   StringStamped.msg
   TimeStamped.msg
   UInt16Stamped.msg

--- a/marti_nav_msgs/CMakeLists.txt
+++ b/marti_nav_msgs/CMakeLists.txt
@@ -1,20 +1,35 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(marti_nav_msgs)
 
-find_package(catkin REQUIRED COMPONENTS
+set(MSG_DEPS
+  geometry_msgs
+  marti_common_msgs
+  std_msgs
+)
+
+set(BUILD_DEPS
+  ${MSG_DEPS}
   message_generation
-  std_msgs)
+)
+
+set(RUNTIME_DEPS
+  ${MSG_DEPS}
+  message_runtime
+)
+
+find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
 
 add_message_files(FILES
   Command.msg
   LeadVehicle.msg
   PathPlanning.msg
+  Route.msg
+  RoutePoint.msg
+  RoutePosition.msg
   TeleopState.msg
   VehicleControl.msg
 )
 
-generate_messages(DEPENDENCIES std_msgs)
+generate_messages(DEPENDENCIES ${MSG_DEPS})
 
-catkin_package(
-  CATKIN_DEPENDS message_runtime std_msgs
-)
+catkin_package(CATKIN_DEPENDS ${RUNTIME_DEPS})

--- a/marti_nav_msgs/msg/RoutePosition.msg
+++ b/marti_nav_msgs/msg/RoutePosition.msg
@@ -1,0 +1,7 @@
+# Position along route
+
+Header  header   # only stamp used
+string  id       # unique ID of nearest point
+float32 distance # forward along route, in meters from point identified by id
+                 # field (negative values indicate the distance is backward
+                 # along the route)

--- a/marti_nav_msgs/package.xml
+++ b/marti_nav_msgs/package.xml
@@ -16,6 +16,8 @@
   <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
+  <depend>geometry_msgs</depend>
+  <depend>marti_common_msgs</depend>
   <depend>std_msgs</depend>
 
 </package>


### PR DESCRIPTION
Add `RoutePosition` message and include all four new messages in the build files:

* `marti_common_msgs/KeyValue`
* `marti_nav_msgs/Route`
* `marti_nav_msgs/RoutePoint`
* `marti_nav_msgs/RoutePosition`

Because `marti_nav_msgs` needed more dependencies, I also refactored the `CMakeLists.txt` to reduce the redundancy and potential for error.