### PR TITLE
Adding KeyValueArray message.

### DIFF
--- a/marti_common_msgs/CMakeLists.txt
+++ b/marti_common_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ add_message_files(FILES
   Int64Stamped.msg
   Int8Stamped.msg
   KeyValue.msg
+  KeyValueArray.msg
   StringStamped.msg
   TimeStamped.msg
   UInt16Stamped.msg

--- a/marti_common_msgs/msg/KeyValueArray.msg
+++ b/marti_common_msgs/msg/KeyValueArray.msg
@@ -1,0 +1,5 @@
+# A generic message for publishing a list of key value pairs directly.
+
+Header header
+
+KeyValue[] items


### PR DESCRIPTION
This message is meant to be useful when you just need to publish a
list of KeyValue pairs directly instead of including a list in another
message.