### PR TITLE
Add Obstacle/ObstacleArray messages to marti_nav_msgs. (indigo)

### DIFF
--- a/marti_nav_msgs/CMakeLists.txt
+++ b/marti_nav_msgs/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
 add_message_files(FILES
   Command.msg
   LeadVehicle.msg
+  Obstacle.msg
+  ObstacleArray.msg
   PathPlanning.msg
   Route.msg
   RoutePoint.msg

--- a/marti_nav_msgs/msg/Obstacle.msg
+++ b/marti_nav_msgs/msg/Obstacle.msg
@@ -1,0 +1,10 @@
+string id
+# Unique id for the obstacle or empty if not used.
+
+geometry_msgs/Pose pose
+# The pose of the origin of the obstacle.
+
+geometry_msgs/Point[] polygon
+# A list of points that define the obstacle's geometry in horizontal
+# plane relative to the obstacle's pose.  The polygon is implicitly
+# closed by a segment between the last and first points.

--- a/marti_nav_msgs/msg/ObstacleArray.msg
+++ b/marti_nav_msgs/msg/ObstacleArray.msg
@@ -1,0 +1,8 @@
+# This message is used to communicate the position of one or more
+# obstacles.
+
+Header header
+# The header defines the frame that the obstacles are defined in.
+
+Obstacle[] obstacles
+# List of obstacles


### PR DESCRIPTION
This commit adds basic obstacle/obstacle array messages that can be used to report object detections and slow/stop a vehicle based on the distance to an obstacle.  These messages are deliberately simple to avoid making poor design decisions about obstacle prediction/uncertainty at this point

Marc - If these look good to you, please merge them in and let Ed D. know.  Otherwise feel free to make any more changes.  I'll make a separate pull request for Jade after we settle on the message format.