### PR TITLE
Add new services to save a route and to update a route's metadata

### DIFF
--- a/marti_nav_msgs/CMakeLists.txt
+++ b/marti_nav_msgs/CMakeLists.txt
@@ -40,7 +40,9 @@ add_service_files(FILES
   GetRouteList.srv
   PlanRoute.srv
   SaveRecordedRoute.srv
+  SaveRoute.srv
   SetRoute.srv
+  UpdateRouteMetadata.srv
 )
 
 generate_messages(DEPENDENCIES ${MSG_DEPS})

--- a/marti_nav_msgs/srv/SaveRoute.srv
+++ b/marti_nav_msgs/srv/SaveRoute.srv
@@ -1,0 +1,7 @@
+string name # Name to save the route as
+string guid # GUID of the route, as 32 hex digits
+marti_nav_msgs/Route route # The route that should be saved
+string thumbnail # base64-encoded JPG or PNG thumbnail image
+---
+bool success # indicate successful run of triggered service
+string message # informational, e. g. for error messages

--- a/marti_nav_msgs/srv/UpdateRouteMetadata.srv
+++ b/marti_nav_msgs/srv/UpdateRouteMetadata.srv
@@ -1,0 +1,14 @@
+# This service is intended for modifying the properties on an existing route 
+# and its points.
+# 
+# The use of this service is a little non-intuitive.  Set route_guid to the GUID
+# of the route you want to modify, and fill metadata_points with all of the points
+# you want to modify.  The coordinates of the points actually don't matter; the
+# "guid" property will be matched against an existing point in the route, and that
+# point's properties will be replaced with the one in the new point.
+string route_guid # The GUID of the route to modify
+marti_nav_msgs/RoutePoint[] metadata_points # All of the points that should be modified
+---
+bool success
+string message
+


### PR DESCRIPTION
This adds two services:
- SaveRoute
  - Takes a list of route points and saves it
  - If the route's GUID matches an existing route, it will be overwritten
- UpdateRouteMetadata
  - Modifies an existing route
  - Replaces the properties on specified points with new properties