### PR TITLE
Add a Direction message to marti_sensor_msgs

### DIFF
--- a/marti_sensor_msgs/CMakeLists.txt
+++ b/marti_sensor_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ add_message_files(FILES
   Altitude.msg
   DioPortState.msg
   DioRealTimeData.msg
+  Direction.msg
   Exposure.msg
   Gyro.msg
   Velocity.msg

--- a/marti_sensor_msgs/msg/Direction.msg
+++ b/marti_sensor_msgs/msg/Direction.msg
@@ -1,0 +1,15 @@
+# Direction of vehicle motion
+#
+# When combined with an unsigned speed, this message can be used to determine
+# signed vehicle speed
+
+Header  header           # The time and location of the measurement.
+                         # The x-axis in the sensor space is interpreted as the
+                         # axis of linear motion.
+
+int8 BACKWARD=-1
+int8 ZERO=0
+int8 FORWARD=1
+
+int8 direction           # The direction of motion. Positive is forward, negative is
+                         # backward, and 0 is stopped.


### PR DESCRIPTION
This message was formerly defined in a SwRI-internal package, but it makes sense to release it here.