### PR TITLE
Include route id with route position for disambiguation.

### DIFF
--- a/marti_nav_msgs/msg/RoutePosition.msg
+++ b/marti_nav_msgs/msg/RoutePosition.msg
@@ -1,6 +1,7 @@
 # Position along route
 
 Header  header   # only stamp used
+string  route_id # unique ID of the corresponding route
 string  id       # unique ID of nearest point
 float32 distance # forward along route, in meters from point identified by id
                  # field (negative values indicate the distance is backward


### PR DESCRIPTION
Include route id with route position for disambiguation when the current route is replaced by a new route.