### PR TITLE
Add marti_dbw_msgs package

### DIFF
--- a/marti_dbw_msgs/CMakeLists.txt
+++ b/marti_dbw_msgs/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 0.8.0)
+
+project(marti_dbw_msgs)
+
+set(MSG_DEPS 
+  std_msgs)
+
+set(BUILD_DEPS
+  ${MSG_DEPS} 
+  message_generation)
+
+set(RUNTIME_DEPS
+  ${MSG_DEPS} 
+  message_runtime)
+
+### Catkin ###
+find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
+
+### Message Generation ###
+add_message_files(DIRECTORY msg FILES
+  PrimaryControl.msg
+  PrimaryFeedback.msg
+  TransmissionFeedback.msg)
+generate_messages(DEPENDENCIES ${MSG_DEPS})
+
+### More Catkin ###
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS ${RUNTIME_DEPS})
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/marti_dbw_msgs/CMakeLists.txt
+++ b/marti_dbw_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 0.8.0)
+cmake_minimum_required(VERSION 2.8.3)
 
 project(marti_dbw_msgs)
 

--- a/marti_dbw_msgs/include/marti_dbw_msgs/constants.h
+++ b/marti_dbw_msgs/include/marti_dbw_msgs/constants.h
@@ -1,0 +1,41 @@
+#ifndef MARTI_DBW_MSGS_DBW_CONSTANTS_H_
+#define MARTI_DBW_MSGS_DBW_CONSTANTS_H_
+
+namespace marti_dbw_msgs
+{
+// This file includes constants used in the marti_dbw_msgs ROS
+// messages.
+//
+// This approach goes against the ROS convention of defining constants
+// in messages (Although there is precendent for this approach.  e.g,
+// sensor_msgs/image_encodings.h).  By keeping constants in a separate
+// header file, we can add new constants without changing the identity
+// of the message (ie, the md5sum).  This will hopefully reduce
+// development friction overall by allowing us to easily add new
+// states as necessary without having to convert old bag files.
+
+//////////////////////////////////////////////////////////////
+// Transmission ranges
+
+// The unknown range is only valid as feedback. It should not be sent as a control.
+const std::string TRANS_UNKNOWN = "unknown";
+
+const std::string TRANS_PARK = "park";
+const std::string TRANS_NEUTRAL = "neutral";
+const std::string TRANS_REVERSE = "reverse";
+const std::string TRANS_DRIVE_LOW = "drive_low";
+const std::string TRANS_DRIVE_HIGH = "drive_high";
+const std::string TRANS_PIVOT = "pivot";
+
+
+
+//////////////////////////////////////////////////////////////
+// Turn signal states
+
+const std::string TURN_SIGNAL_UNKNOWN = "unknown";
+const std::string TURN_SIGNAL_OFF = "off";
+const std::string TURN_SIGNAL_LEFT = "left";
+const std::string TURN_SIGNAL_RIGHT = "right";
+const std::string TURN_SIGNAL_HAZARDS = "hazards";
+}
+#endif  // MARTI_DBW_MSGS_DBW_CONSTANTS_H_

--- a/marti_dbw_msgs/msg/PrimaryControl.msg
+++ b/marti_dbw_msgs/msg/PrimaryControl.msg
@@ -1,0 +1,13 @@
+Header header
+
+bool active
+bool estop
+
+float32 steering_command
+# Steering command in range [0.0 to 1.0]
+
+float32 throttle_command
+# Throttle command in range [0.0 to 1.0]
+
+float32 brake_command
+# Brake command in range [0.0 to 1.0]

--- a/marti_dbw_msgs/msg/PrimaryFeedback.msg
+++ b/marti_dbw_msgs/msg/PrimaryFeedback.msg
@@ -1,0 +1,34 @@
+Header header
+
+bool present
+# Boolean flag indicating that DBW system is present and communicating
+# properly.  If this is false, none of the remaining data in the
+# feedback can be considered valid.
+
+# Boolean flag indicating that DBW system is in robotic mode.
+bool robotic_mode
+
+float32 steering_command
+float32 steering_measure
+# The current steering command and measured value of the steering
+# axies in the range [0.0 to 1.0].  Typically 0.0 is full left and 1.0
+# is full right, but the steering calibration can handle either
+# direction.
+
+float32 throttle_command
+float32 throttle_measure
+# The current throttle command and measured value of the throttle
+# control in the range [0.0 to 1.0]
+
+float32 brake_command
+float32 brake_measure
+# The current throttle command and measured value of the throttle
+# control in the range [0.0 to 1.0]
+
+bool estop_command
+bool estop_measure
+
+bool error_steering
+bool error_throttle
+bool error_brake
+bool error_other

--- a/marti_dbw_msgs/msg/TransmissionFeedback.msg
+++ b/marti_dbw_msgs/msg/TransmissionFeedback.msg
@@ -1,0 +1,13 @@
+Header header
+
+string current_range
+
+# This is false during shifting when the actuator is moving or
+# settling into the final position.
+bool stable
+
+# This is true when the vehicle is in a reversing gear.
+bool reverse
+
+# This is true when the vehicle is in a forward gear.
+bool forward

--- a/marti_dbw_msgs/package.xml
+++ b/marti_dbw_msgs/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<package format="2">
+  <name>marti_dbw_msgs</name>
+  <version>0.8.0</version>
+  <description>
+
+     marti_dbw_msgs
+
+  </description>
+  <maintainer email="mbries@swri.org">Matthew Bries</maintainer>
+  <url type="repository">https://github.com/swri-robotics/marti_messages</url>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>std_msgs</depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+</package>
+


### PR DESCRIPTION
This adds a few common message for drive by wires, most usefully the TransmissionFeedback message and standard gear names.