### PR TITLE
Add explicit dependencies on std_msgs

### DIFF
--- a/marti_can_msgs/msg/CanFrame.msg
+++ b/marti_can_msgs/msg/CanFrame.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 # Header timestamp is the time when all messages were acquired
 # and synchronized.
 

--- a/marti_common_msgs/msg/BoolStamped.msg
+++ b/marti_common_msgs/msg/BoolStamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 bool   value

--- a/marti_common_msgs/msg/ByteArrayStamped.msg
+++ b/marti_common_msgs/msg/ByteArrayStamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 byte[] value

--- a/marti_common_msgs/msg/DurationStamped.msg
+++ b/marti_common_msgs/msg/DurationStamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 duration value

--- a/marti_common_msgs/msg/Float32Stamped.msg
+++ b/marti_common_msgs/msg/Float32Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 float32 value

--- a/marti_common_msgs/msg/Float64Stamped.msg
+++ b/marti_common_msgs/msg/Float64Stamped.msg
@@ -1,3 +1,3 @@
-Header  header
+std_msgs/Header  header
 
 float64 value

--- a/marti_common_msgs/msg/HealthStatus.msg
+++ b/marti_common_msgs/msg/HealthStatus.msg
@@ -6,7 +6,7 @@ int8 WARN=1  # Component is operating but the data may be inaccurate or there ma
 int8 ERROR=2 # Component has encountered a serious problem and cannot or will not operate
 int8 STALE=3 # Uninitialized or cannot determine status
 
-Header header
+std_msgs/Header header
 
 int8   status
 string message

--- a/marti_common_msgs/msg/Int16Stamped.msg
+++ b/marti_common_msgs/msg/Int16Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 int16 value

--- a/marti_common_msgs/msg/Int32Stamped.msg
+++ b/marti_common_msgs/msg/Int32Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 int32 value

--- a/marti_common_msgs/msg/Int64Stamped.msg
+++ b/marti_common_msgs/msg/Int64Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 int64 value

--- a/marti_common_msgs/msg/Int8Stamped.msg
+++ b/marti_common_msgs/msg/Int8Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 int8 value

--- a/marti_common_msgs/msg/KeyValueArray.msg
+++ b/marti_common_msgs/msg/KeyValueArray.msg
@@ -1,5 +1,5 @@
 # A generic message for publishing a list of key value pairs directly.
 
-Header header
+std_msgs/Header header
 
 KeyValue[] items

--- a/marti_common_msgs/msg/Matrix3x3Stamped.msg
+++ b/marti_common_msgs/msg/Matrix3x3Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 float64[9] matrix

--- a/marti_common_msgs/msg/StringArrayStamped.msg
+++ b/marti_common_msgs/msg/StringArrayStamped.msg
@@ -1,5 +1,5 @@
 # A generic message for publishing a list of strings.
 
-Header header
+std_msgs/Header header
 
 string[] strings

--- a/marti_common_msgs/msg/StringStamped.msg
+++ b/marti_common_msgs/msg/StringStamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 string value

--- a/marti_common_msgs/msg/TimeStamped.msg
+++ b/marti_common_msgs/msg/TimeStamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 time value

--- a/marti_common_msgs/msg/UInt16Stamped.msg
+++ b/marti_common_msgs/msg/UInt16Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 uint16 value

--- a/marti_common_msgs/msg/UInt32Stamped.msg
+++ b/marti_common_msgs/msg/UInt32Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 uint32 value

--- a/marti_common_msgs/msg/UInt64Stamped.msg
+++ b/marti_common_msgs/msg/UInt64Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 uint64 value

--- a/marti_common_msgs/msg/UInt8Stamped.msg
+++ b/marti_common_msgs/msg/UInt8Stamped.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 uint8 value

--- a/marti_dbw_msgs/msg/PrimaryControl.msg
+++ b/marti_dbw_msgs/msg/PrimaryControl.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 bool active
 bool estop

--- a/marti_dbw_msgs/msg/PrimaryFeedback.msg
+++ b/marti_dbw_msgs/msg/PrimaryFeedback.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 bool present
 # Boolean flag indicating that DBW system is present and communicating

--- a/marti_dbw_msgs/msg/TransmissionFeedback.msg
+++ b/marti_dbw_msgs/msg/TransmissionFeedback.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 string current_range
 

--- a/marti_nav_msgs/msg/Command.msg
+++ b/marti_nav_msgs/msg/Command.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
 int32[] startstop

--- a/marti_nav_msgs/msg/GridMap.msg
+++ b/marti_nav_msgs/msg/GridMap.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 # Map extents in the header frame.
 geometry_msgs/Point top_left

--- a/marti_nav_msgs/msg/LeadVehicle.msg
+++ b/marti_nav_msgs/msg/LeadVehicle.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 float32 headwayDistance
 float32 speed

--- a/marti_nav_msgs/msg/ObstacleArray.msg
+++ b/marti_nav_msgs/msg/ObstacleArray.msg
@@ -1,7 +1,7 @@
 # This message is used to communicate the position of one or more
 # obstacles.
 
-Header header
+std_msgs/Header header
 # The header defines the frame that the obstacles are defined in.
 
 Obstacle[] obstacles

--- a/marti_nav_msgs/msg/PathPlanning.msg
+++ b/marti_nav_msgs/msg/PathPlanning.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 int32   segment_type    # Type of path segment
 float32 length          # Length of path segment

--- a/marti_nav_msgs/msg/Route.msg
+++ b/marti_nav_msgs/msg/Route.msg
@@ -1,3 +1,3 @@
-Header                         header
+std_msgs/Header                header
 RoutePoint[]                   route_points
 marti_common_msgs/KeyValue[]   properties

--- a/marti_nav_msgs/msg/RouteArray.msg
+++ b/marti_nav_msgs/msg/RouteArray.msg
@@ -1,6 +1,6 @@
 # list of muliple routes, for instance to support multi-lane roads
 
-Header                         header
+std_msgs/Header                header
 
 marti_nav_msgs/Route[]         routes
 

--- a/marti_nav_msgs/msg/RouteOffset.msg
+++ b/marti_nav_msgs/msg/RouteOffset.msg
@@ -1,6 +1,6 @@
 # Gives a position and orientation relative to a position on a route
 
-Header header                                 # only stamp used
+std_msgs/Header header                        # only stamp used
 
 geometry_msgs/Pose relative_pose              # pose relative to position on route
 marti_nav_msgs/RoutePosition route_position   # position on route

--- a/marti_nav_msgs/msg/RoutePosition.msg
+++ b/marti_nav_msgs/msg/RoutePosition.msg
@@ -1,6 +1,6 @@
 # Position along route
 
-Header  header   # only stamp used
+std_msgs/Header  header # only stamp used
 string  route_id # unique ID of the corresponding route
 string  id       # unique ID of nearest point
 float32 distance # forward along route, in meters from point identified by id

--- a/marti_nav_msgs/msg/RouteSpeed.msg
+++ b/marti_nav_msgs/msg/RouteSpeed.msg
@@ -1,6 +1,6 @@
 # Speed at a position along route
 
-Header  header   # only stamp used
+std_msgs/Header  header   # only stamp used
 string  id       # unique ID of nearest point
 float32 distance # forward along route, in meters from point identified by id
                  # field (negative values indicate the distance is backward

--- a/marti_nav_msgs/msg/RouteSpeedArray.msg
+++ b/marti_nav_msgs/msg/RouteSpeedArray.msg
@@ -1,6 +1,6 @@
 # List of target speeds along a route.
 
-Header header        # only stamp used
+std_msgs/Header header # only stamp used
 
 RouteSpeed[] speeds
 # List of speeds along a route. The interpretation of the list is

--- a/marti_nav_msgs/msg/TeleopState.msg
+++ b/marti_nav_msgs/msg/TeleopState.msg
@@ -1,3 +1,3 @@
-Header header	
+std_msgs/Header header
 
 int32[] teleopSignals

--- a/marti_nav_msgs/msg/TrackedObject.msg
+++ b/marti_nav_msgs/msg/TrackedObject.msg
@@ -2,7 +2,7 @@ uint8 VEHICLE=0
 uint8 PEDESTRIAN=1
 uint8 UNKNOWN=255
 
-Header header  # Frame and timestamp
+std_msgs/Header header  # Frame and timestamp
 uint16 id      # Id
 
 geometry_msgs/PoseWithCovariance pose      # Pose in the header frame.

--- a/marti_nav_msgs/msg/TrackedObjectArray.msg
+++ b/marti_nav_msgs/msg/TrackedObjectArray.msg
@@ -1,5 +1,5 @@
 # This message is used to communicate tracking data for one or more objects.
 
-Header header            # The frame that the objects are defined in.
+std_msgs/Header header   # The frame that the objects are defined in.
 
 TrackedObject[] objects  # The tracked objects.

--- a/marti_nav_msgs/msg/VehicleControl.msg
+++ b/marti_nav_msgs/msg/VehicleControl.msg
@@ -1,4 +1,4 @@
-Header 		header
+std_msgs/Header 		header
 
 int32 		engine
 int32 		gear

--- a/marti_nav_msgs/msg/Wgs84Sample.msg
+++ b/marti_nav_msgs/msg/Wgs84Sample.msg
@@ -3,7 +3,7 @@
 # (e.g. antenna) location in a vehicle's relative odometry coordinate
 # frame.
 
-Header header
+std_msgs/Header header
 # The header contains the /tf name of the relative odometry frame and
 # the timestamp of the measurement.
 

--- a/marti_nav_msgs/srv/PlanRoute.srv
+++ b/marti_nav_msgs/srv/PlanRoute.srv
@@ -1,4 +1,4 @@
-Header header                  # the frame the request and response are
+std_msgs/Header header         # the frame the request and response are
                                # referenced in
 
 geometry_msgs/Pose[] waypoints # series of points the route should pass through

--- a/marti_perception_msgs/msg/PedestrianImageID.msg
+++ b/marti_perception_msgs/msg/PedestrianImageID.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 int32 pixel_x
 int32 pixel_y

--- a/marti_sensor_msgs/msg/Altitude.msg
+++ b/marti_sensor_msgs/msg/Altitude.msg
@@ -1,4 +1,4 @@
 # Altitude estimate for the origin of the frame specified by header.frame_id
-Header               header      
+std_msgs/Header                header
 float64						   altitude  # meters above sea level
 float64						   sigma     # Uncertainty (standard deviation) of the altitude

--- a/marti_sensor_msgs/msg/DifferentialMeasurement.msg
+++ b/marti_sensor_msgs/msg/DifferentialMeasurement.msg
@@ -1,7 +1,7 @@
 # A differential measurement between two places in the world
 #  Usually used with RTK-gps setups
 
-Header  header           # The time and location where this measurement is taken from
+std_msgs/Header  header  # The time and location where this measurement is taken from
 string  base_frame_id    # The location we are measuring relative to
 
 float64 baseline_length  # Distance in meters between the two locations

--- a/marti_sensor_msgs/msg/DioPortState.msg
+++ b/marti_sensor_msgs/msg/DioPortState.msg
@@ -2,7 +2,7 @@
 # the rtd_dm7820 driver to send digital input changes and accept
 # digital output commands.
 
-Header header
+std_msgs/Header header
 # header contains the time that the event occurred.
 
 uint64 value

--- a/marti_sensor_msgs/msg/DioRealTimeData.msg
+++ b/marti_sensor_msgs/msg/DioRealTimeData.msg
@@ -1,6 +1,6 @@
 # Message for containing digital data obtained by a real-time DAQ.
 
-Header header
+std_msgs/Header header
 # header contains the timestamp of when this data was obtained from
 # the device.
 

--- a/marti_sensor_msgs/msg/Direction.msg
+++ b/marti_sensor_msgs/msg/Direction.msg
@@ -3,7 +3,7 @@
 # When combined with an unsigned speed, this message can be used to determine
 # signed vehicle speed
 
-Header  header           # The time and location of the measurement.
+std_msgs/Header  header  # The time and location of the measurement.
                          # The x-axis in the sensor space is interpreted as the
                          # axis of linear motion.
 

--- a/marti_sensor_msgs/msg/Exposure.msg
+++ b/marti_sensor_msgs/msg/Exposure.msg
@@ -2,7 +2,7 @@
 # message header.  This message is to keep the same format
 # that we have with Image and CameraInfo.
 
-Header header                    # Header timestamp is the time when all 
+std_msgs/Header header           # Header timestamp is the time when all 
                                  # images were acquired and synchronized.
                                  # Header frame_id is the count of these
                                  # messages sent since the start.

--- a/marti_sensor_msgs/msg/Gyro.msg
+++ b/marti_sensor_msgs/msg/Gyro.msg
@@ -1,6 +1,6 @@
 # Single axis gyro reading.
 
-Header  header           # The time and location of the measurement.
+std_msgs/Header  header  # The time and location of the measurement.
                          # The x-axis in the sensor space is interpreted as the
                          # axis of rotation.
                          

--- a/marti_sensor_msgs/msg/Velocity.msg
+++ b/marti_sensor_msgs/msg/Velocity.msg
@@ -1,6 +1,6 @@
 # Single axis linear velocity reading.
 
-Header  header           # The time and location of the measurement.
+std_msgs/Header  header  # The time and location of the measurement.
                          # The x-axis in the sensor space is interpreted as the
                          # axis of linear motion.
                          

--- a/marti_sensor_msgs/msg/WheelEncoderSet.msg
+++ b/marti_sensor_msgs/msg/WheelEncoderSet.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 
-WheelEncoder[] encoders
+marti_sensor_msgs/WheelEncoder[] encoders

--- a/marti_sensor_msgs/package.xml
+++ b/marti_sensor_msgs/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>message_runtime</exec_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
 
 </package>
 

--- a/marti_status_msgs/msg/ChronyTrackingStatus.msg
+++ b/marti_status_msgs/msg/ChronyTrackingStatus.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 
 string reference
 int32 stratum

--- a/marti_visualization_msgs/msg/TexturedMarker.msg
+++ b/marti_visualization_msgs/msg/TexturedMarker.msg
@@ -2,7 +2,7 @@ uint8 ADD=0
 uint8 MODIFY=0
 uint8 DELETE=2
 
-Header              header
+std_msgs/Header     header
 
 string              ns           # Namespace to place this object in... used in
                                  # conjunction with id to create a unique name

--- a/marti_visualization_msgs/package.xml
+++ b/marti_visualization_msgs/package.xml
@@ -18,5 +18,6 @@
   
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   
 </package>


### PR DESCRIPTION
Many messages used "Header" without clarifying which package it was
from, and a few package.xml files did not specify a dependency on std_msgs,
which could cause an issue in some build environments.  This explicitly
adds it everywhere.

Signed-off-by: P. J. Reed <preed@swri.org>