### PR TITLE
use correct syntax for add_message_files (#1)

### DIFF
--- a/marti_introspection_msgs/CMakeLists.txt
+++ b/marti_introspection_msgs/CMakeLists.txt
@@ -5,11 +5,13 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   std_msgs)
 
-add_message_files(FILES
-  NodeInfo.msg
-  ParamInfo.msg
-  TopicInfo.msg
-  ServiceInfo.msg
+add_message_files(
+  DIRECTORY msg 
+  FILES
+    NodeInfo.msg
+    ParamInfo.msg
+    TopicInfo.msg
+    ServiceInfo.msg
 )
 
 generate_messages(DEPENDENCIES


### PR DESCRIPTION
when clean-building a workspace, dependent packages have trouble finding this package. Using the correct syntax per the documentation:

http://docs.ros.org/en/jade/api/catkin/html/howto/format2/building_msgs.html#cmakelists-txt

seems to remedy the problem.

