### PR TITLE
Fixing Imports

### DIFF
--- a/marti_dbw_msgs/CMakeLists.txt
+++ b/marti_dbw_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(marti_dbw_msgs)
 
-# Default to C++14
+# Default to C++ version appropriate for the ROS distribution
 if(NOT CMAKE_CXX_STANDARD)
   if ("$ENV{ROS_DISTRO}" STRGREATER "foxy")
     set(CMAKE_CXX_STANDARD 17)

--- a/marti_dbw_msgs/CMakeLists.txt
+++ b/marti_dbw_msgs/CMakeLists.txt
@@ -1,7 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 project(marti_dbw_msgs)
 
-set(CMAKE_CXX_STANDARD 14)
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  if ("$ENV{ROS_DISTRO}" STRGREATER "foxy")
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 set(MSG_DEPS 
   builtin_interfaces 
@@ -23,10 +33,41 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES ${MSG_DEPS}
 )
 
-install(DIRECTORY include/
-  DESTINATION include
-)
+if("$ENV{ROS_DISTRO}" STRGREATER "galactic")
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target
+    "${PROJECT_NAME}"
+    "rosidl_typesupport_cpp")
+
+
+  if(cpp_typesupport_target)
+    add_library(${PROJECT_NAME}_library INTERFACE)
+    target_include_directories(${PROJECT_NAME}_library INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+    target_link_libraries(${PROJECT_NAME}_library INTERFACE
+    "${cpp_typesupport_target}")
+
+    install(DIRECTORY include/
+      DESTINATION include/${PROJECT_NAME}
+    )
+    install(
+      TARGETS ${PROJECT_NAME}_library EXPORT export_${PROJECT_NAME}
+    )
+
+    # Export old-style CMake variables
+    ament_export_include_directories("include/${PROJECT_NAME}")
+
+    # Export modern CMake targets
+    ament_export_targets(export_${PROJECT_NAME})
+  endif()
+else()
+  install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION include/${PROJECT_NAME}
+  )
+  ament_export_include_directories(include)
+endif()
 
 ament_export_dependencies(rosidl_default_runtime)
-ament_package()
 
+ament_package()


### PR DESCRIPTION
Mimics the build process of `sensor_msgs` to provide the header files in the same way.