### PR TITLE
Add cost to PlanRoute srv

### DIFF
--- a/marti_nav_msgs/srv/PlanRoute.srv
+++ b/marti_nav_msgs/srv/PlanRoute.srv
@@ -10,3 +10,4 @@ Route  route     # planned route
 
 bool success     # indicate successful run of service
 string message   # informational, e.g. for error messages
+float64 cost 	 # informational, cost of route


### PR DESCRIPTION
This PR exposes the cost of a `marti_nav_msgs/Route` as determined by the planning algorithm.