### PR TITLE
Fixed number of dashes in SetExposure Service call

### DIFF
--- a/marti_sensor_msgs/srv/SetExposure.srv
+++ b/marti_sensor_msgs/srv/SetExposure.srv
@@ -1,5 +1,5 @@
 bool auto_exposure
 int64 time
-----
+---
 bool auto_exposure
 int64 time


### PR DESCRIPTION
Fix the number of dashes in a service call separating the request and response. I am using some auto-generating code that is complaining about this.