### PR TITLE
Added constant for reverse_low gear string

### DIFF
--- a/marti_dbw_msgs/include/marti_dbw_msgs/constants.h
+++ b/marti_dbw_msgs/include/marti_dbw_msgs/constants.h
@@ -26,6 +26,7 @@ const std::string TRANS_REVERSE = "reverse";
 const std::string TRANS_DRIVE_LOW = "drive_low";
 const std::string TRANS_DRIVE_HIGH = "drive_high";
 const std::string TRANS_PIVOT = "pivot";
+const std::string TRANS_REVERSE_LOW = "reverse_low";
 
 
 


### PR DESCRIPTION
Adding a transmission gear string constant to the constants.h header in marti_dbw_msgs for a "reverse_low" gear